### PR TITLE
Persist player session and handle disconnections

### DIFF
--- a/src/Components/GameProvider/GameProvider.tsx
+++ b/src/Components/GameProvider/GameProvider.tsx
@@ -36,7 +36,15 @@ const GameProvider = (props: Props) => {
 
   // * only supposed to run once, at the beginning
   useEffect(() => {
-    socket.connect();
+    const sessionID = localStorage.getItem("sessionID");
+
+    if (sessionID) {
+      socket.auth = { sessionID, nickname };
+      socket.connect();
+    } else {
+      socket.connect();
+    }
+
     socket.on("connect_error", (err) => {
       // TODO handle connection error
       if (err.message === "invalid nickname") {
@@ -75,6 +83,15 @@ const GameProvider = (props: Props) => {
       const newPlayers = [...players];
       newPlayers.push(user);
       setPlayers(newPlayers);
+    });
+
+    socket.on("session", ({ sessionID, userID, roomCode }) => {
+      // attach the session ID to the next reconnection attempts
+      socket.auth = { sessionID, nickname };
+      // store it in the localStorage
+      localStorage.setItem("sessionID", sessionID);
+      // save the ID of the user
+      socket.userID = userID;
     });
 
     return () => {

--- a/src/common/socket/socket.ts
+++ b/src/common/socket/socket.ts
@@ -1,9 +1,10 @@
-import { io, Socket } from "socket.io-client";
+import { io } from "socket.io-client";
+import { MiSocket } from "../types";
 
 const URL = "http://localhost:3000";
 
 const newSocket = (gameCode: string, nickname: string | undefined) => {
-  const socket: Socket = io(URL, {
+  const socket: MiSocket = io(URL, {
     autoConnect: false,
     query: { gameCode },
     auth: { nickname },

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,7 @@
 import { RouteComponentProps } from "react-router-dom";
 import { StaticContext } from "react-router";
+import { Socket } from "socket.io-client";
+import { DefaultEventsMap } from "socket.io-client/build/typed-events";
 
 export type RoutePropsType = RouteComponentProps<{}, StaticContext, unknown>;
 
@@ -19,3 +21,7 @@ export type User = {
   messages: Array<string>;
   hasNewMessages: boolean;
 };
+
+export interface MiSocket extends Socket<DefaultEventsMap, DefaultEventsMap> {
+  userID?: string;
+}


### PR DESCRIPTION
Persist player session across all tabs and reconnection plus handle disconnections from both players (client side).